### PR TITLE
feat: add native version bumpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@
               ${{ runner.os }}-build-
               ${{ runner.os }}-
         - run: npm ci
+        - run: npm run build
         - run: npm test
         - run: npm run lint
-        - run: npm run build

--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ module.exports = {
 };
 ```
 
+If you're using the [bare workflow][link-bare-workflow], you'll need a couple
+more bumpers to keep your native project config files in sync:
+
+```js
+// .versionrc.js
+const sdkVersion = '37.0.0';  // or pull from app.json
+
+module.exports = [
+  // ...
+  {
+    filename: 'ios/<YourAppName>/Info.plist',
+    updater: require.resolve('standard-version-expo/ios/native/app-version'),
+  },
+  {
+    filename: 'ios/<YourAppName>/Info.plist',
+    updater: require.resolve('standard-version-expo/ios/native/buildnum/increment'),
+  },
+  {
+    filename: 'android/app/build.gradle',
+    updater: require.resolve('standard-version-expo/android/native/app-version'),
+  },
+  {
+    filename: 'android/app/build.gradle',
+    updater: require.resolve('standard-version-expo/android/native/buildnum/code')(sdkVersion),
+  },
+];
+```
+
 To test if your configuration works as expected, you can run standard version in dry mode.
 This shows you what will happen, without actually applying the versions and tags.
 
@@ -87,6 +115,28 @@ updater             | example      | description
 `ios/increment`     | `9`          | Replace `expo.ios.buildNumber` with an incremental version.
 `ios/version`       | `3.2.1`      | Replace `expo.ios.buildNumber` with the exact calculated semver. (**recommended**)
 
+And for the native build config files:
+
+updater                         | example       | file path                      | description
+---                             | ---           | ---                            | ---
+`native/ios/app-version`        | `3.2.1`       | `ios/<YourAppName>/Info.plist` | Replace `CFBundleShortVersionString` with the exact calculated semver.
+`native/ios/buildnum/code`      | `36030201`    | `ios/<YourAppName>/Info.plist` | Replace `CFBundleVersion` with the [method described by Maxi Rosson][link-version-code].
+`native/ios/buildnum/increment` | `8`           | `ios/<YourAppName>/Info.plist` | Replace `CFBundleVersion` with an incremental version.
+`native/ios/buildnum/version`   | `3.2.1`       | `ios/<YourAppName>/Info.plist` | Replace `CFBundleVersion` with the exact calculated semver. (**recommended**)
+`native/android/app-version`        | `3.2.1`       | `android/app/build.gradle` | Replace `versionName` with the exact calculated semver.
+`native/android/buildnum/code`      | `36030201`    | `android/app/build.gradle` | Replace `versionCode` with the [method described by Maxi Rosson][link-version-code]. (**recommended**)
+`native/android/buildnum/increment` | `8`           | `android/app/build.gradle` | Replace `versionCode` with an incremental version.
+
+Note that the `native/{ios,android}/buildnum/code` bumpers are only supported
+in `.versionrc.js` file, not in `.versionrc` or `.versionrc.json` files.
+Since a bumper only operates on one file, the Expo manifest is unavailable to
+the bumper when it's operating on a native build config file. Because of this,
+you must provide the Expo SDK version via javascript (see example above).
+
+However, this means that you can also use these bumpers with non-Expo React
+Native projects, and even plain Android projects, simply by supplying the
+minimum Android API level rather than the Expo SDK version.
+
 ### Version code
 
 Semver is one of the most popular versioning methods; it generates a string with a syntax that even humans can read.
@@ -108,3 +158,4 @@ It's a deterministic solution that removes some of the ambiguity of incremental 
 [link-expo-version]: https://docs.expo.io/versions/latest/workflow/configuration#version
 [link-standard-version]: https://github.com/conventional-changelog/standard-version#configuration
 [link-version-code]: https://medium.com/@maxirosson/versioning-android-apps-d6ec171cfd82
+[link-bare-workflow]: https://docs.expo.io/introduction/managed-vs-bare/

--- a/android/native/app-version.js
+++ b/android/native/app-version.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/android-app-version');

--- a/android/native/buildnum/code.js
+++ b/android/native/buildnum/code.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/android-code');
+module.exports = require('../../../build/bumpers/native/buildnum/android-code').default;

--- a/android/native/buildnum/code.js
+++ b/android/native/buildnum/code.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/android-code');

--- a/android/native/buildnum/increment.js
+++ b/android/native/buildnum/increment.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/android-increment');
+module.exports = require('../../../build/bumpers/native/buildnum/android-increment');

--- a/android/native/buildnum/increment.js
+++ b/android/native/buildnum/increment.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/android-increment');

--- a/android/native/buildnum/index.js
+++ b/android/native/buildnum/index.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/android-code');
+module.exports = require('../../../build/bumpers/native/buildnum/android-code').default;

--- a/android/native/buildnum/index.js
+++ b/android/native/buildnum/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/android-code');

--- a/ios/native/app-version.js
+++ b/ios/native/app-version.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/ios-app-version');

--- a/ios/native/buildnum/code.js
+++ b/ios/native/buildnum/code.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/ios-code');

--- a/ios/native/buildnum/code.js
+++ b/ios/native/buildnum/code.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/ios-code');
+module.exports = require('../../../build/bumpers/native/buildnum/ios-code').default;

--- a/ios/native/buildnum/increment.js
+++ b/ios/native/buildnum/increment.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/ios-increment');

--- a/ios/native/buildnum/increment.js
+++ b/ios/native/buildnum/increment.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/ios-increment');
+module.exports = require('../../../build/bumpers/native/buildnum/ios-increment');

--- a/ios/native/buildnum/index.js
+++ b/ios/native/buildnum/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/ios-version');

--- a/ios/native/buildnum/index.js
+++ b/ios/native/buildnum/index.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/ios-version');
+module.exports = require('../../../build/bumpers/native/buildnum/ios-version');

--- a/ios/native/buildnum/version.js
+++ b/ios/native/buildnum/version.js
@@ -1,0 +1,1 @@
+module.exports = require('../../build/bumpers/native/buildnum/ios-version');

--- a/ios/native/buildnum/version.js
+++ b/ios/native/buildnum/version.js
@@ -1,1 +1,1 @@
-module.exports = require('../../build/bumpers/native/buildnum/ios-version');
+module.exports = require('../../../build/bumpers/native/buildnum/ios-version');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,8 +1362,16 @@
 		"@types/node": {
 			"version": "13.13.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.0.tgz",
-			"integrity": "sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A==",
-			"dev": true
+			"integrity": "sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A=="
+		},
+		"@types/plist": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.2.tgz",
+			"integrity": "sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==",
+			"requires": {
+				"@types/node": "*",
+				"xmlbuilder": ">=11.0.1"
+			}
 		},
 		"@types/prettier": {
 			"version": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
 	"dependencies": {
 		"@expo/config": "^3.1.2",
 		"@expo/json-file": "^8.2.10",
+		"@types/plist": "^3.0.2",
 		"detect-indent": "^6.0.0",
 		"detect-newline": "^3.1.0",
 		"globby": "^11.0.0",
+		"plist": "^3.0.1",
 		"semver": "^7.3.2"
 	},
 	"devDependencies": {

--- a/src/bumpers/native/android-app-version.ts
+++ b/src/bumpers/native/android-app-version.ts
@@ -1,0 +1,11 @@
+import { androidAppVersionReader, androidAppVersionWriter } from './helpers';
+
+/**
+ * Read the app version from the `versionName` build.gradle property.
+ */
+export const readVersion = androidAppVersionReader;
+
+/**
+ * Write the app version to the `versionName` build.gradle property.
+ */
+export const writeVersion = androidAppVersionWriter;

--- a/src/bumpers/native/buildnum/android-code.ts
+++ b/src/bumpers/native/buildnum/android-code.ts
@@ -1,0 +1,42 @@
+import { androidBuildnumReader, androidBuildnumWriter } from '../helpers';
+import { getVersionCodeFromSdkVersion } from '../../../versions';
+
+/**
+ * Since a standard-version bumper only receives the contents of a single file,
+ * we add a layer of indirection here and ask the user to supply the sdkVersion
+ * directly. Note that they can choose to pull this from app.json, or even supply
+ * the Android min SDK version if they're not using Expo.
+ * 
+ * Configuration example in .versionrc.js:
+ *
+ *     const sdkVersion = '37.0.0';  // or pull from app.json
+ *     module.exports = [
+ *         ...
+ *         {
+ *             filename: 'android/app/build.gradle',
+ *             updater: require.resolve('standard-version-expo/android/native/code')(sdkVersion),
+ *         },
+ *         ...
+ *     ];
+ *
+ * This does add the requirement that they use .versionrc.js, not the other formats.
+ */
+export default (sdkVersion: string) => ({
+	/**
+	 * Read the build code from the `versionCode` property.
+	 */
+	readVersion: androidBuildnumReader,
+
+	/**
+	 * Write the manifest version to the `versionCode` property.
+	 * This uses the Android version code approach of Maxi Rosson.
+	 *
+	 * @see https://medium.com/@maxirosson/versioning-android-apps-d6ec171cfd82
+	 */
+	writeVersion: (contents: string, version: string) => androidBuildnumWriter(
+		contents,
+		String(
+			getVersionCodeFromSdkVersion(sdkVersion, version),
+		),
+	),
+});

--- a/src/bumpers/native/buildnum/android-increment.ts
+++ b/src/bumpers/native/buildnum/android-increment.ts
@@ -1,0 +1,24 @@
+import { androidBuildnumReader, androidBuildnumWriter } from '../helpers';
+import { VersionWriter } from '../../../types';
+
+/**
+ * Read the buildnum stored at versionCode in the build.gradle.
+ */
+export const readVersion = androidBuildnumReader;
+
+/**
+ * Increment the buildnum stored at versionCode in the build.gradle.
+ * This ignores the provided version.
+ */
+export const writeVersion: VersionWriter = (contents, _version) => {
+	const buildNumStr = androidBuildnumReader(contents);
+	const buildNumber = buildNumStr != ''
+		? Number(buildNumStr)
+		: 0;
+
+	if (Number.isNaN(buildNumber)) {
+		throw new Error('Could not parse number from `versionCode`.');
+	}
+
+	return androidBuildnumWriter(contents, String(buildNumber + 1));
+};

--- a/src/bumpers/native/buildnum/ios-code.ts
+++ b/src/bumpers/native/buildnum/ios-code.ts
@@ -1,0 +1,42 @@
+import { iosBuildnumReader, iosBuildnumWriter } from '../helpers';
+import { getVersionCodeFromSdkVersion } from '../../../versions';
+
+/**
+ * Since a standard-version bumper only receives the contents of a single file,
+ * we add a layer of indirection here and ask the user to supply the sdkVersion
+ * directly. Note that they can choose to pull this from app.json, or even supply
+ * the Android min SDK version if they're not using Expo.
+ * 
+ * Configuration example in .versionrc.js:
+ *
+ *     const sdkVersion = '37.0.0';  // or pull from app.json
+ *     module.exports = [
+ *         ...
+ *         {
+ *             filename: 'ios/MyApp/Info.plist',
+ *             updater: require.resolve('standard-version-expo/ios/native/code')(sdkVersion),
+ *         },
+ *         ...
+ *     ];
+ *
+ * This does add the requirement that they use .versionrc.js, not the other formats.
+ */
+export default (sdkVersion: string) => ({
+	/**
+	 * Read the build code from the `CFBundleVersion` property.
+	 */
+	readVersion: iosBuildnumReader,
+
+	/**
+	 * Write the manifest version to the `CFBundleVersion` property.
+	 * This uses the Android version code approach of Maxi Rosson.
+	 *
+	 * @see https://medium.com/@maxirosson/versioning-android-apps-d6ec171cfd82
+	 */
+	writeVersion: (contents: string, version: string) => iosBuildnumWriter(
+		contents,
+		String(
+			getVersionCodeFromSdkVersion(sdkVersion, version),
+		),
+	),
+});

--- a/src/bumpers/native/buildnum/ios-increment.ts
+++ b/src/bumpers/native/buildnum/ios-increment.ts
@@ -1,0 +1,24 @@
+import { iosBuildnumReader, iosBuildnumWriter } from '../helpers';
+import { VersionWriter } from '../../../types';
+
+/**
+ * Read the buildnum stored at CFBundleVersion in the Info.plist.
+ */
+export const readVersion = iosBuildnumReader;
+
+/**
+ * Increment the buildnum stored at CFBundleVersion in the Info.plist.
+ * This ignores the provided version.
+ */
+export const writeVersion: VersionWriter = (contents, _version) => {
+	const buildNumStr = iosBuildnumReader(contents);
+	const buildNumber = buildNumStr != ''
+		? Number(buildNumStr)
+		: 0;
+
+	if (Number.isNaN(buildNumber)) {
+		throw new Error('Could not parse number from `CFBundleVersion`.');
+	}
+
+	return iosBuildnumWriter(contents, String(buildNumber + 1));
+};

--- a/src/bumpers/native/buildnum/ios-version.ts
+++ b/src/bumpers/native/buildnum/ios-version.ts
@@ -1,0 +1,11 @@
+import { iosBuildnumReader, iosBuildnumWriter } from '../helpers';
+
+/**
+ * Read the build version stored at CFBundleVersion in the Info.plist.
+ */
+export const readVersion = iosBuildnumReader;
+
+/**
+ * Write the manifest version at CFBundleVersion in the Info.plist.
+ */
+export const writeVersion = iosBuildnumWriter;

--- a/src/bumpers/native/helpers.ts
+++ b/src/bumpers/native/helpers.ts
@@ -105,7 +105,14 @@ const iosWriteVersion = (contents: string, key: string, value: string): string =
  * It replaces the value in the `Info.plist` contents and returns the new contents as string.
  */
 export const iosAppVersionWriter: VersionWriter = (contents, version) => (
-	iosWriteVersion(contents, 'CFBundleShortVersionString', version)
+	iosWriteVersion(
+		contents,
+		'CFBundleShortVersionString',
+
+		// trim any prerelease suffixes; this string
+		// must strictly be an x.y.z version.
+		version.split('-')[0],
+	)
 );
 
 /**

--- a/src/bumpers/native/helpers.ts
+++ b/src/bumpers/native/helpers.ts
@@ -1,0 +1,117 @@
+import os from 'os';
+
+import plist, { PlistObject } from 'plist';
+
+import { VersionReader, VersionWriter } from '../../types';
+
+const androidAppVersionRegex = /^(.+versionName +["']?)([^"']+)(["']?.*)$/;
+const androidBuildnumRegex = /^(.+versionCode +["']?)([0-9]+)(["']?.*)$/;
+
+const replaceMatchingLines = (contents: string, rx: RegExp, version: string): string => {
+	// it's a PITA to make sure we insert it in the right place,
+	// and it's always there in the generated android project,
+	// so if we don't find it, throw an error.
+	if (!findMatchingLine(contents, rx)) {
+		let field;
+		if (rx === androidAppVersionRegex) {
+			field = 'versionName';
+		} else if (rx === androidBuildnumRegex) {
+			field = 'versionCode';
+		} else {
+			throw new Error('NOTREACHED');
+		}
+		throw new Error(`Could not find ${field} in build.gradle`)
+	}
+
+	return contents.split(os.EOL)
+		.map(line => line.replace(rx, `$1${version}$3`))
+		.join(os.EOL)
+};
+
+const findMatchingLine = (contents: string, rx: RegExp): string => {
+	for (const line of contents.split(os.EOL)) {
+		const match = line.match(rx);
+		if (match) {
+			return match[2];
+		}
+	}
+	return '';
+}
+
+/**
+ * The default android app version reader.
+ * It reads the value from `android/app/build.gradle` and returns it as string.
+ */
+export const androidAppVersionReader: VersionReader = (contents) => (
+	findMatchingLine(contents, androidAppVersionRegex)
+);
+
+/**
+ * The default android buildnum reader.
+ * It reads the value from `android/app/build.gradle` and returns it as string.
+ */
+export const androidBuildnumReader: VersionReader = (contents) => (
+	findMatchingLine(contents, androidBuildnumRegex)
+);
+
+
+/**
+ * The default android app version writer.
+ * It replaces the value in the `android/app/build.gradle` contents and
+ * returns the new contents as string.
+ */
+export const androidAppVersionWriter: VersionWriter = (contents, version) => (
+	replaceMatchingLines(contents, androidAppVersionRegex, version)
+);
+
+/**
+ * The default android buildnum writer.
+ * It replaces the value in the `android/app/build.gradle` contents and
+ * returns the new contents as string.
+ */
+export const androidBuildnumWriter: VersionWriter = (contents, version) => (
+	replaceMatchingLines(contents, androidBuildnumRegex, version)
+);
+
+const iosReadVersion = (contents: string, key: string): string => (
+	(plist.parse(contents) as PlistObject)[key] as string || ''
+)
+
+/**
+ * The default ios app version reader.
+ * It reads the value from `Info.plist` and returns it as string.
+ */
+export const iosAppVersionReader: VersionReader = (contents) => (
+	iosReadVersion(contents, 'CFBundleShortVersionString')
+);
+
+/**
+ * The default ios buildnum reader.
+ * It reads the value from `Info.plist` and returns it as string.
+ */
+export const iosBuildnumReader: VersionReader = (contents) => (
+	iosReadVersion(contents, 'CFBundleVersion')
+);
+
+const iosWriteVersion = (contents: string, key: string, value: string): string => (
+	plist.build({
+		...(plist.parse(contents) as PlistObject),
+		[key]: value,
+	})
+)
+
+/**
+ * The default ios app version writer.
+ * It replaces the value in the `Info.plist` contents and returns the new contents as string.
+ */
+export const iosAppVersionWriter: VersionWriter = (contents, version) => (
+	iosWriteVersion(contents, 'CFBundleShortVersionString', version)
+);
+
+/**
+ * The default ios buildnum writer.
+ * It replaces the value in the `Info.plist` contents and returns the new contents as string.
+ */
+export const iosBuildnumWriter: VersionWriter = (contents, version) => (
+	iosWriteVersion(contents, 'CFBundleVersion', version)
+);

--- a/src/bumpers/native/ios-app-version.ts
+++ b/src/bumpers/native/ios-app-version.ts
@@ -1,0 +1,11 @@
+import { iosAppVersionReader, iosAppVersionWriter } from './helpers';
+
+/**
+ * Read the app version from the `CFBundleShortVersionString` Info.plist property.
+ */
+export const readVersion = iosAppVersionReader;
+
+/**
+ * Write the app version to the `CFBundleShortVersionString` Info.plist property.
+ */
+export const writeVersion = iosAppVersionWriter;

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -8,8 +8,12 @@ import { coerce as semver } from 'semver';
  * @see https://medium.com/@maxirosson/versioning-android-apps-d6ec171cfd82
  */
 export function getVersionCode(manifest: AppJSONConfig, version: string): number {
-	const sdk = getExpoSDKVersion(process.cwd(), manifest.expo);
-	const expo = semver(sdk);
+	const sdkVersion = getExpoSDKVersion(process.cwd(), manifest.expo);
+	return getVersionCodeFromSdkVersion(sdkVersion, version);
+}
+
+export function getVersionCodeFromSdkVersion(sdkVersion: string, version: string): number {
+	const expo = semver(sdkVersion);
 	const target = semver(version);
 
 	if (!expo) {

--- a/test/aliases.test.ts
+++ b/test/aliases.test.ts
@@ -1,0 +1,21 @@
+import globby from 'globby';
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+describe('bumper aliases', () => {
+	const aliases = globby.sync(['android/**/*', 'ios/**/*']);
+	aliases.forEach(path => {
+		describe(path, () => {
+			it('is importable', () => {
+				const bumperModule = require(`../${path}`);
+
+				let bumper = bumperModule;
+				if (bumperModule instanceof Function) {
+					bumper = bumperModule('37.0.0');  // dummy SDK version
+				}
+				expect(bumper.readVersion).toBeInstanceOf(Function);
+				expect(bumper.writeVersion).toBeInstanceOf(Function);
+			});
+		});
+	})
+});

--- a/test/bumpers/native/android-app-version.test.ts
+++ b/test/bumpers/native/android-app-version.test.ts
@@ -1,0 +1,38 @@
+import * as stub from '../../stub';
+import { readVersion, writeVersion } from '../../../src/bumpers/native/android-app-version';
+
+describe('readVersion', () => {
+	it('returns android app version from build.gradle', () => {
+		const version = '4.2.1';
+		const buildGradle = stub.androidBuildGradle(version);
+
+		expect(readVersion(buildGradle)).toBe(version);
+	});
+
+	it('returns empty string by default', () => {
+		const buildGradle = stub.androidBuildGradle();
+		const buildGradleNoAppVersion = buildGradle.replace(/\t+versionName +[0-9.'"]+/m, '');
+
+		expect(readVersion(buildGradleNoAppVersion)).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	it('returns build.gradle with modified android app version', () => {
+		const newVersion = '3.2.1';
+		const buildGradle = stub.androidBuildGradle();
+		expect(readVersion(buildGradle)).not.toBe(newVersion);
+
+		const modified = writeVersion(buildGradle, newVersion);
+
+		expect(readVersion(modified)).toBe(newVersion);
+	});
+
+	it('throws if android app version is missing', () => {
+		const version = '1.2.3';
+		const buildGradle = stub.androidBuildGradle();
+		const buildGradleNoAppVersion = buildGradle.replace(/\t+versionName +[0-9.'"]+/m, '');
+
+		expect(() => writeVersion(buildGradleNoAppVersion, version)).toThrow();
+	});
+});

--- a/test/bumpers/native/buildnum/android-code.test.ts
+++ b/test/bumpers/native/buildnum/android-code.test.ts
@@ -1,0 +1,54 @@
+import * as stub from '../../../stub';
+import androidCodeBumper from '../../../../src/bumpers/native/buildnum/android-code';
+import { getVersionCodeFromSdkVersion } from '../../../../src/versions';
+
+describe('readVersion', () => {
+	const sdkVersion = '37.0.0';
+	const { readVersion } = androidCodeBumper(sdkVersion);
+
+	it('returns android build number from build.gradle', () => {
+		const version = '1.0.0';
+		const buildnum = '370010000';
+		const buildGradle = stub.androidBuildGradle(version, buildnum);
+
+		expect(readVersion(buildGradle)).toBe(
+			String(getVersionCodeFromSdkVersion(sdkVersion, version))
+		);
+	});
+
+	it('returns empty string by default', () => {
+		const buildGradle = stub.androidBuildGradle();
+		expect(readVersion(buildGradle)).not.toBe('');
+
+		const buildGradleNoBuildnum = buildGradle.replace(/\t+versionCode +[0-9]+/m, '');
+
+		expect(readVersion(buildGradleNoBuildnum)).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	const sdkVersion = '37.0.0';
+	const { readVersion, writeVersion } = androidCodeBumper(sdkVersion);
+
+	it('returns build.gradle with modified android build number', () => {
+		const version = '3.2.1';
+		const expectedBuildnum = '370030201';
+		const buildGradle = stub.androidBuildGradle(version, '123');
+		expect(readVersion(buildGradle)).not.toBe(expectedBuildnum);
+
+		const modified = writeVersion(buildGradle, version);
+
+		expect(readVersion(modified)).toBe(expectedBuildnum);
+	});
+
+	it('throws if android build number is missing', () => {
+		const oldBuildnum = '370030201';
+		const oldVersion = '3.2.1';
+		const version = '1.2.3';
+
+		const buildGradle = stub.androidBuildGradle(oldVersion, oldBuildnum);
+		const buildGradleNoBuildnum = buildGradle.replace(/\t+versionCode +[0-9]+/m, '');
+
+		expect(() => writeVersion(buildGradleNoBuildnum, version)).toThrow();
+	});
+});

--- a/test/bumpers/native/buildnum/android-increment.test.ts
+++ b/test/bumpers/native/buildnum/android-increment.test.ts
@@ -1,0 +1,40 @@
+import * as stub from '../../../stub';
+import { readVersion, writeVersion } from '../../../../src/bumpers/native/buildnum/android-increment';
+
+describe('readVersion', () => {
+	it('returns android build number from build.gradle', () => {
+		const buildnum = '5';
+		const buildGradle = stub.androidBuildGradle(undefined, buildnum);
+
+		expect(readVersion(buildGradle)).toBe(buildnum);
+	});
+
+	it('returns empty string by default', () => {
+		const buildGradle = stub.androidBuildGradle();
+		expect(readVersion(buildGradle)).not.toBe('');
+
+		const buildGradleNoBuildnum = buildGradle.replace(/\t+versionCode +[0-9]+/m, '');
+
+		expect(readVersion(buildGradleNoBuildnum)).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	it('returns build.gradle with modified android build number', () => {
+		const oldBuildNum = '4';
+		const newBuildNum = '5';
+		const buildGradle = stub.androidBuildGradle(undefined, oldBuildNum);
+		expect(readVersion(buildGradle)).not.toBe(newBuildNum);
+
+		const modified = writeVersion(buildGradle, 'ignored');
+
+		expect(readVersion(modified)).toBe(newBuildNum);
+	});
+
+	it('throws if android build number is missing', () => {
+		const buildGradle = stub.androidBuildGradle();
+		const buildGradleNoBuildnum = buildGradle.replace(/\t+versionCode +[0-9]+/m, '');
+
+		expect(() => writeVersion(buildGradleNoBuildnum, 'ignored')).toThrow();
+	});
+});

--- a/test/bumpers/native/buildnum/ios-code.test.ts
+++ b/test/bumpers/native/buildnum/ios-code.test.ts
@@ -1,0 +1,64 @@
+import plist, { PlistObject } from 'plist';
+
+import * as stub from '../../../stub';
+import iosCodeBumper from '../../../../src/bumpers/native/buildnum/ios-code';
+import { getVersionCodeFromSdkVersion } from '../../../../src/versions';
+
+describe('readVersion', () => {
+	const sdkVersion = '37.0.0';
+	const { readVersion } = iosCodeBumper(sdkVersion);
+
+	it('returns ios build number from Info.plist', () => {
+		const version = '1.0.0';
+		const buildnum = '370010000';
+		const infoPlist = stub.iosInfoPlist(version, buildnum);
+
+		expect(readVersion(infoPlist)).toBe(
+			String(getVersionCodeFromSdkVersion(sdkVersion, version))
+		);
+	});
+
+	it('returns empty string by default', () => {
+		const infoPlistStr = stub.iosInfoPlist();
+		const infoPlist: PlistObject = plist.parse(infoPlistStr) as PlistObject;
+		expect(readVersion(infoPlistStr)).not.toBe('');
+
+		const writable = { ...infoPlist };
+		delete writable.CFBundleVersion;
+
+		expect(readVersion(plist.build(writable))).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	const sdkVersion = '37.0.0';
+	const { readVersion, writeVersion } = iosCodeBumper(sdkVersion);
+
+	it('returns Info.plist with modified ios build number', () => {
+		const version = '3.2.1';
+		const expectedBuildnum = '370030201';
+		const infoPlistStr = stub.iosInfoPlist(version, '123');
+		expect(readVersion(infoPlistStr)).not.toBe(expectedBuildnum);
+
+		const modified = writeVersion(infoPlistStr, version);
+
+		expect(readVersion(modified)).toBe(expectedBuildnum);
+	});
+
+	it('returns Info.plist with added ios build number', () => {
+		const oldBuildnum = '370030201';
+		const oldVersion = '3.2.1';
+		const version = '1.2.3';
+		const newBuildnum = '370010203';
+
+		const infoPlistStr = stub.iosInfoPlist(oldVersion, oldBuildnum);
+		const infoPlist: PlistObject = plist.parse(infoPlistStr) as PlistObject;
+
+		const writable = { ...infoPlist };
+		delete writable.CFBundleVersion;
+
+		const modified = writeVersion(plist.build(writable), version);
+
+		expect(readVersion(modified)).toBe(newBuildnum);
+	});
+});

--- a/test/bumpers/native/buildnum/ios-increment.test.ts
+++ b/test/bumpers/native/buildnum/ios-increment.test.ts
@@ -1,0 +1,46 @@
+import plist, { PlistObject } from 'plist';
+
+import * as stub from '../../../stub';
+import { readVersion, writeVersion } from '../../../../src/bumpers/native/buildnum/ios-increment';
+
+describe('readVersion', () => {
+	it('returns ios build number from Info.plist', () => {
+		const buildnum = '5';
+		const infoPlist = stub.iosInfoPlist(undefined, buildnum);
+
+		expect(readVersion(infoPlist)).toBe(buildnum);
+	});
+
+	it('returns empty string by default', () => {
+		const infoPlistStr = stub.iosInfoPlist();
+		const infoPlist: PlistObject = plist.parse(infoPlistStr) as PlistObject;
+		expect(readVersion(infoPlistStr)).not.toBe('');
+
+		const writable = { ...infoPlist };
+		delete writable.CFBundleVersion;
+
+		expect(readVersion(plist.build(writable))).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	it('returns Info.plist with modified ios build number', () => {
+		const buildnum = '5';
+		const infoPlist = stub.iosInfoPlist(undefined, buildnum);
+
+		const modified = writeVersion(infoPlist, 'ignored');
+		expect(readVersion(modified)).toBe('6');
+	});
+
+	it('returns Info.plist with added ios build number', () => {
+		const infoPlistStr = stub.iosInfoPlist();
+		const infoPlist: PlistObject = plist.parse(infoPlistStr) as PlistObject;
+
+		const writable = { ...infoPlist };
+		delete writable.CFBundleVersion;
+
+		const modified = writeVersion(plist.build(writable), 'ignored');
+
+		expect(readVersion(modified)).toBe('1');
+	});
+});

--- a/test/bumpers/native/buildnum/ios-version.test.ts
+++ b/test/bumpers/native/buildnum/ios-version.test.ts
@@ -1,0 +1,48 @@
+import plist, { PlistObject } from 'plist';
+
+import * as stub from '../../../stub';
+import { readVersion, writeVersion } from '../../../../src/bumpers/native/buildnum/ios-version';
+
+describe('readVersion', () => {
+	it('returns ios build number from Info.plist', () => {
+		const buildnum = '3.2.1';
+		const infoPlist = stub.iosInfoPlist(undefined, buildnum);
+
+		expect(readVersion(infoPlist)).toBe(buildnum);
+	});
+
+	it('returns empty string by default', () => {
+		const infoPlistStr = stub.iosInfoPlist();
+		const infoPlist: PlistObject = plist.parse(infoPlistStr) as PlistObject;
+		expect(readVersion(infoPlistStr)).not.toBe('');
+
+		const writable = { ...infoPlist };
+		delete writable.CFBundleVersion;
+
+		expect(readVersion(plist.build(writable))).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	it('returns Info.plist with modified ios build number', () => {
+		const buildnum = '1.2.3';
+		const infoPlist = stub.iosInfoPlist(undefined, buildnum);
+
+		const newBuildnum = '1.2.4';
+		const modified = writeVersion(infoPlist, newBuildnum);
+		expect(readVersion(modified)).toBe(newBuildnum);
+	});
+
+	it('returns Info.plist with added ios build number', () => {
+		const infoPlistStr = stub.iosInfoPlist();
+		const infoPlist: PlistObject = plist.parse(infoPlistStr) as PlistObject;
+
+		const writable = { ...infoPlist };
+		delete writable.CFBundleVersion;
+
+		const newBuildnum = '1.2.3';
+		const modified = writeVersion(plist.build(writable), newBuildnum);
+
+		expect(readVersion(modified)).toBe(newBuildnum);
+	});
+});

--- a/test/bumpers/native/ios-app-version.test.ts
+++ b/test/bumpers/native/ios-app-version.test.ts
@@ -1,0 +1,45 @@
+import plist, { PlistObject } from 'plist';
+
+import * as stub from '../../stub';
+import { readVersion, writeVersion } from '../../../src/bumpers/native/ios-app-version';
+
+describe('readVersion', () => {
+	it('returns ios app version from Info.plist', () => {
+		const version = '4.2.1';
+		const infoPlistStr = stub.iosInfoPlist(version);
+
+		expect(readVersion(infoPlistStr)).toBe(version);
+	});
+
+	it('returns empty string by default', () => {
+		const infoPlist: PlistObject = plist.parse(stub.iosInfoPlist()) as PlistObject;
+		const writable = { ...infoPlist };
+		delete writable.CFBundleShortVersionString;
+
+		expect(readVersion(plist.build(writable))).toBe('');
+	});
+});
+
+describe('writeVersion', () => {
+	it('returns Info.plist with modified ios app version', () => {
+		const newVersion = '3.2.1';
+		const infoPlistStr = stub.iosInfoPlist();
+		expect(readVersion(infoPlistStr)).not.toBe(newVersion);
+
+		const modified = writeVersion(infoPlistStr, newVersion);
+
+		expect(readVersion(modified)).toBe(newVersion);
+	});
+
+	it('returns Info.plist with added ios app version', () => {
+		const version = '1.2.3';
+		const infoPlist = plist.parse(stub.iosInfoPlist()) as PlistObject;
+		const writable = { ...infoPlist };
+		delete writable.CFBundleShortVersionString;
+		expect(readVersion(plist.build(writable))).toBe('');
+
+		const modified = writeVersion(plist.build(writable), version);
+
+		expect(readVersion(modified)).toBe(version);
+	});
+});

--- a/test/stub.ts
+++ b/test/stub.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+
 import { AppJSONConfig } from '@expo/config';
 
 /**
@@ -29,3 +31,54 @@ export const manifestRaw = `{
  * It's a function that returns new objects to avoid mutating the original data.
  */
 export const manifest = () => JSON.parse(manifestRaw) as AppJSONConfig;
+
+/**
+ * Minimal Info.plist from an iOS project, for testing purposes.
+ */
+export const iosInfoPlistRaw = `
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>VERSION</string>
+	<key>CFBundleVersion</key>
+	<string>BUILDNUM</string>
+</dict>
+</plist>
+`;
+
+/**
+ * Minimal app/build.gradle file from an Android project, for testing purposes.
+ */
+export const androidBuildGradleRaw = [
+	'	android {',
+	'		defaultConfig {',
+	'			versionName "VERSION"',
+	'			versionCode BUILDNUM',
+	'		}',
+	'	}',
+	'',
+].join(os.EOL);
+
+type StubGenerator = (version?: string, buildnum?: string) => string;
+
+const makeStubGenerator = (content: string): StubGenerator => (
+	(version = '1.0.0', buildnum = '42') => (
+		content
+			.replace('VERSION', version)
+			.replace('BUILDNUM', buildnum)
+	)
+);
+
+/**
+ * The example Info.plist, but cloned, for testing purposes.
+ * It's a function that returns new objects to avoid mutating the original data.
+ */
+export const iosInfoPlist: StubGenerator = makeStubGenerator(iosInfoPlistRaw);
+
+/**
+ * The example app/build.gradle, but cloned, for testing purposes.
+ * It's a function that returns new objects to avoid mutating the original data.
+ */
+export const androidBuildGradle: StubGenerator = makeStubGenerator(androidBuildGradleRaw);

--- a/test/versions/get-version-code.test.ts
+++ b/test/versions/get-version-code.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import * as stub from '../stub';
-import { getVersionCode } from '../../src/versions';
+import { getVersionCode, getVersionCodeFromSdkVersion } from '../../src/versions';
 
 describe('getVersionCode', () => {
 	it('throws when `expo.sdkVersion` is missing', () => {
@@ -47,5 +47,15 @@ describe('getVersionCode', () => {
 		delete manifest.expo.sdkVersion;
 
 		expect(getVersionCode(manifest, '3.2.1')).toBe(370030201);
+	});
+});
+
+describe('getVersionCodeFromSdkVersion', () => {
+	it('returns 370030201 for sdk 37 and version 3.2.1', () => {
+		expect(getVersionCodeFromSdkVersion('37.0.0', '3.2.1')).toBe(370030201);
+	});
+
+	it('returns 280030201 for API level 28 and version 3.2.1', () => {
+		expect(getVersionCodeFromSdkVersion('28', '3.2.1')).toBe(280030201);
 	});
 });


### PR DESCRIPTION
Adds app version and build number bumpers for the native iOS/Android
project configuration files (e.g. Info.plist, build.gradle).
These are usable by expo bare workflow projects, but also react-native
projects that don't use Expo, and even plain old iOS/Android projects.

### Linked issue
Closes #9.

### Additional context
Not yet tested with a real project, but I'm going to do that tomorrow. It might also be real nice to get integration tests set up that take a real project and bump its version, and then verify that all the right files have all the right versions.