### PR TITLE
feat: added the 'timestamp' bumper to bump the versionCode or buildNumber to Date.now()

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,20 @@ Standard Version's version bumpers are pretty simple; each bump only updates a s
 This package exposes multiple kinds of updaters, for different areas of the manifest.
 You can "compose" your own set of `bumpFiles` entries to suit your needs.
 
-| updater             | example     | description                                                                                                         |
-| ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------- |
-| `<root>`            | `3.2.1`     | _alias of `manifest/version`_                                                                                       |
-| `manifest`          | `3.2.1`     | _alias of `manifest/version`_                                                                                       |
-| `manifest/version`  | `3.2.1`     | Replace `expo.version` with the exact calculated semver. (**recommended**)                                          |
-| `android`           | `360030201` | _alias of `android/code`_                                                                                           |
-| `android/code`      | `350010000` | Replace `expo.android.versionCode` with the [method described by Maxi Rosson][link-version-code]. (**recommended**) |
-| `android/increment` | `8`         | Replace `expo.android.versionCode` with an incremental version.                                                     |
-| `ios`               | `3.2.1`     | _alias of `ios/version`_                                                                                            |
-| `ios/code`          | `360030201` | Replace `expo.ios.buildNumber` with the [method described by Maxi Rosson][link-version-code].                       |
-| `ios/increment`     | `9`         | Replace `expo.ios.buildNumber` with an incremental version.                                                         |
-| `ios/version`       | `3.2.1`     | Replace `expo.ios.buildNumber` with the exact calculated semver. (**recommended**)                                  |
+| updater             | example         | description                                                                                                         |
+| ------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `<root>`            | `3.2.1`         | _alias of `manifest/version`_                                                                                       |
+| `manifest`          | `3.2.1`         | _alias of `manifest/version`_                                                                                       |
+| `manifest/version`  | `3.2.1`         | Replace `expo.version` with the exact calculated semver. (**recommended**)                                          |
+| `android`           | `360030201`     | _alias of `android/code`_                                                                                           |
+| `android/code`      | `350010000`     | Replace `expo.android.versionCode` with the [method described by Maxi Rosson][link-version-code]. (**recommended**) |
+| `android/increment` | `8`             | Replace `expo.android.versionCode` with an incremental version.                                                     |
+| `android/timestamp` | `1642622748128` | Replace `expo.android.versionCode` with the result of `Date.now()`.                                                 |
+| `ios`               | `3.2.1`         | _alias of `ios/version`_                                                                                            |
+| `ios/code`          | `360030201`     | Replace `expo.ios.buildNumber` with the [method described by Maxi Rosson][link-version-code].                       |
+| `ios/increment`     | `9`             | Replace `expo.ios.buildNumber` with an incremental version.                                                         |
+| `ios/version`       | `3.2.1`         | Replace `expo.ios.buildNumber` with the exact calculated semver. (**recommended**)                                  |
+| `ios/timestamp`     | `1642622748128` | Replace `expo.ios.buildNumber` with the result of `Date.now()`.                                                     |
 
 ### Version code
 

--- a/android/timestamp.js
+++ b/android/timestamp.js
@@ -1,0 +1,1 @@
+module.exports = require('../build/bumpers/expo-android-timestamp');

--- a/ios/timestamp.js
+++ b/ios/timestamp.js
@@ -1,0 +1,1 @@
+module.exports = require('../build/bumpers/expo-ios-timestamp');

--- a/src/bumpers/expo-android-timestamp.ts
+++ b/src/bumpers/expo-android-timestamp.ts
@@ -1,0 +1,19 @@
+import { parse, serialize, androidVersionReader } from '../parsers/expo';
+import { VersionWriter } from '../types';
+
+/**
+ * Read the manifest version from the `expo.android.versionCode` property.
+ */
+export const readVersion = androidVersionReader;
+
+/**
+ * Write the manifest version to the `expo.android.versionCode` property.
+ * This uses the an incremental approach, and ignores the provided version.
+ */
+export const writeVersion: VersionWriter = (contents, _version) => {
+  const manifest = parse(contents);
+  manifest.expo.android = manifest.expo.android || {};
+  manifest.expo.android.versionCode = Date.now();
+
+  return serialize(manifest, contents);
+};

--- a/src/bumpers/expo-ios-timestamp.ts
+++ b/src/bumpers/expo-ios-timestamp.ts
@@ -1,0 +1,18 @@
+import { parse, serialize, iosVersionReader } from '../parsers/expo';
+import { VersionWriter } from '../types';
+
+/**
+ * Read the manifest version from the `expo.ios.buildNumber` property.
+ */
+export const readVersion = iosVersionReader;
+
+/**
+ * Write the manifest version to the `expo.ios.buildNumber` property.
+ */
+export const writeVersion: VersionWriter = (contents, version) => {
+  const manifest = parse(contents);
+  manifest.expo.ios = manifest.expo.ios || {};
+  manifest.expo.ios.buildNumber = String(Date.now());
+
+  return serialize(manifest, contents);
+};


### PR DESCRIPTION
feat: added the 'timestamp' bumper to bump the versionCode or buildNumber to Date.now()